### PR TITLE
fix bug adding shortForm and title to Trait document

### DIFF
--- a/scripts/document_types/trait.py
+++ b/scripts/document_types/trait.py
@@ -57,6 +57,9 @@ def get_trait_data(connection, limit=0):
                 mapped_trait_document['efoLink'] = [mapped_trait[1]+"|"+\
                     mapped_trait[5]+"|"+mapped_trait[2]]
 
+                mapped_trait_document['shortForm'] = [mapped_trait[5]]
+                mapped_trait_document['title'] = mapped_trait[1]
+
                 # Add Autosuggest fields
                 mapped_trait_document['shortform_autosuggest'] = [mapped_trait[5]]
                 mapped_trait_document['label_autosuggest'] = [mapped_trait[1]]
@@ -109,9 +112,6 @@ def get_trait_data(connection, limit=0):
 
                     # Not all EFO terms will be in OLS when the Solr data 
                     # is generated so use the shortForm from the database
-                    mapped_trait_document['shortForm'] = mapped_trait[5]
-
-                    mapped_trait_document['title'] = mapped_trait[1]
 
 
                     #######################


### PR DESCRIPTION
There were some bugs with the earlier commit, the shortForm field was not formatted as multivalued and the shortForm and title fields needed to be out of the scope of querying OLS since these fields are not created based on any data from OLS now.