### PR TITLE
add description for terms not yet in OLS

### DIFF
--- a/scripts/document_types/trait.py
+++ b/scripts/document_types/trait.py
@@ -121,6 +121,7 @@ def get_trait_data(connection, limit=0):
                     if not ols_term_data['description'] == None:
                         term_description = ''.join(ols_term_data['description'])
                     else:
+                        # handle terms that do not have a term definition
                         term_description = "NA"
 
                     mapped_trait_document['description'] = term_description+", associations: "+\
@@ -147,8 +148,14 @@ def get_trait_data(connection, limit=0):
 
                 else:
                     # TODO: Handle cases when term is not
-                    # in EFO submitted to OLS
-                   pass
+                    # yet in published EFO submitted to OLS
+                    
+                    # add description since this is a required field for the Solr documents
+                    term_description = "NA"
+
+                    mapped_trait_document['description'] = term_description+", associations: "+\
+                    str(mapped_trait_document['associationCount'])+", studies: "+str(mapped_trait_document['studyCount'])
+                    print "** Trait: ", mapped_trait[5]
 
 
                 ############################################

--- a/scripts/document_types/trait.py
+++ b/scripts/document_types/trait.py
@@ -155,7 +155,7 @@ def get_trait_data(connection, limit=0):
 
                     mapped_trait_document['description'] = term_description+", associations: "+\
                     str(mapped_trait_document['associationCount'])+", studies: "+str(mapped_trait_document['studyCount'])
-                    print "** Trait: ", mapped_trait[5]
+                    
 
 
                 ############################################


### PR DESCRIPTION
The EFO term description is pulled from OLS. Since EFO is published and loaded into OLS monthly (15th of the month) there can be cases where a term is used in the GWAS data, but not yet in OLS. Since the EFO term description is part of the Trait Solr document description this should fix cases when the EFO term is not yet in OLS so the document will still have a description.
