### PR TITLE
Unique set of mapped gene names is generated.

### DIFF
--- a/scripts/document_types/variant.py
+++ b/scripts/document_types/variant.py
@@ -31,6 +31,7 @@ def get_variant_data(connection, limit=0):
         # Extracting mapped genes:
         mapped_genes_list = variant_cls.get_mapped_genes(ID)
         mapped_genes_names = [x.split("|")[0] for x in mapped_genes_list]
+        mapped_genes_names = list(set(mapped_genes_names)) # GOCI-2475 - unique set of names are generated.
 
         # Extracting merged rsID:
         current_rsID = variant_cls.get_current_rsID(ID)


### PR DESCRIPTION
No multiplication of mapped gene names for variants mapped to patch region. Just the addition of a single line in the variant.py module that ensures a gene name is not repeated multiple times in the variant description. Demonstrating the effect:

Old document description: "6:32711222|6p21.32|Intergenic variant|MTCO3P1,MTCO3P1,MTCO3P1,MTCO3P1,MTCO3P1,MTCO3P1,AL662789.1"

New document description: "6:32711222|6p21.32|Intergenic variant|AL662789.1,MTCO3P1"