### PR TITLE
Handling unicode characters in the title of the publications.

### DIFF
--- a/scripts/database/DBConnection.py
+++ b/scripts/database/DBConnection.py
@@ -15,7 +15,7 @@ class gwasCatalogDbConnector(object):
         try:
             ip, port, sid, username, password = gwas_data_sources.get_db_properties(self.database_name) # noqa
             dsn_tns = cx_Oracle.makedsn(ip, port, sid)
-            self.connection = cx_Oracle.connect(username, password, dsn_tns)
+            self.connection = cx_Oracle.connect(username, password, dsn_tns, encoding='UTF-8', nencoding='UTF-8')
             self.cursor = self.connection.cursor()
             print ("[INFO] Database connection successful")
 

--- a/scripts/document_types/publication.py
+++ b/scripts/document_types/publication.py
@@ -11,10 +11,17 @@ import os.path
 # import gwas_data_sources
 
 
-def get_publication_data(connection, limit=0):
+def get_publication_data(connection, limit=0, testRun = False):
     '''
     Get Publication data for Solr document.
     '''
+
+    # List of PMIDs of publications that are special in some way (as string!):
+    testPmidSet = [
+        '22569225', # Special character in title
+        '27911795', # Special character in title
+        '29309628'  # Special non-printed character in title
+    ]
 
     # List of queries
     publication_sql = """
@@ -103,6 +110,10 @@ def get_publication_data(connection, limit=0):
             publication_data = cursor.fetchall()
 
             for publication in tqdm(publication_data, desc='Get Publication data'):  # noqa
+
+                # If a test run is called, skip all publications except which are listed in the test set:
+                if testRun and not publication[1] in testPmidSet: continue 
+
                 publication = list(publication)
 
                 publication_document = {}

--- a/scripts/generate_solr_docs.py
+++ b/scripts/generate_solr_docs.py
@@ -19,13 +19,13 @@ from document_types import variant
 from document_types import gene
 from document_types import gene_annotator
 
-def publication_data(connection, limit=0):
-    return publication.get_publication_data(connection)
+def publication_data(connection, limit=0, test=False):
+    return publication.get_publication_data(connection, testRun = test)
 
-def trait_data(connection, limit=0):
+def trait_data(connection, limit=0, test=False):
     return trait.get_trait_data(connection)
 
-def study_data(connection, limit=0):
+def study_data(connection, limit=0, test=False):
     return study.get_study_data(connection)
 
 def check_data(data, doctype):
@@ -87,10 +87,10 @@ def save_data(data, data_type=None):
     with open(path, 'w') as outfile:
         outfile.write(jsonData)
 
-def variant_data(connection, limit=0):
+def variant_data(connection, limit=0, test=False):
     return variant.get_variant_data(connection, limit)
 
-def gene_data(connection, limit=0):
+def gene_data(connection, limit=0, test=False):
     return gene.get_gene_data(connection, RESTURL, limit)
 
 if __name__ == '__main__':
@@ -106,13 +106,15 @@ if __name__ == '__main__':
     parser.add_argument('--document', default='publication',
                         choices=['publication', 'trait', 'variant', 'gene', 'all'],
                         help='Run as (default: publication).')
-    parser.add_argument('--restURL', default = 'https://jul2018.rest.ensembl.org', help = 'URL of Ensembl REST API. Determines which Ensembl release will be used.')
+    parser.add_argument('--restURL', default = 'https://rest.ensembl.org', help = 'URL of Ensembl REST API. Determines which Ensembl release will be used.')
+    parser.add_argument('--test', help = 'Generate ducments on a test set. (needs to be implemented to each document types1!)', action = 'store_true', default=False)
     args = parser.parse_args()
 
     global DATABASE_NAME
     DATABASE_NAME = args.database
 
     limit = args.limit
+    test = args.test
 
     global RESTURL  
     RESTURL = args.restURL
@@ -138,7 +140,7 @@ if __name__ == '__main__':
 
     # Loop through all the document types and generate document
     for doc in documents:
-        document_data = dispatcher[doc](db_object.connection, limit)
+        document_data = dispatcher[doc](db_object.connection, limit, test)
         document_data = check_data(document_data, doc)
         # save_data(document_data, docfileSuffix)
         save_data(document_data)


### PR DESCRIPTION
This pull request addresses the issue with publications having special characters in their title. To fix that the database connection had to be opened in a way that supports UTF8 encoding. 

Also I have added an extra command line option: `--test` it allows to call the document generation on a smaller, specific set of DB entries. In this case a set of special PMIDs. This feature allows a more efficient bug fixing and testing in the future.  