### PR TITLE
Goci 2540 ds finding missing variant

### DIFF
--- a/scripts/document_types/variant.py
+++ b/scripts/document_types/variant.py
@@ -2,7 +2,7 @@
 import pandas as pd
 from tqdm import tqdm
 
-def get_variant_data(connection, limit=0, test = False):
+def get_variant_data(connection, limit=0, testRun = False):
     '''
     Get Variant data for Solr document.
     '''
@@ -65,7 +65,6 @@ def get_variant_data(connection, limit=0, test = False):
             'studyCount' : study_count,
             'mappedGenes' : mapped_genes_list,
             'consequence' : consequence,
-            'link' : 'variants/%s' % rsID
         }
 
         # Adding only valid location indicated by integer position:
@@ -98,7 +97,7 @@ def get_variant_data(connection, limit=0, test = False):
     # Step 3: Calling apply to retrieve all variant data:
     if limit != 0:
         variants_df[0:limit].progress_apply(get_more_variant_data, axis = 1)
-    elif test:
+    elif testRun:
         variants_df[variants_df['ID'].isin(testAssociationId)].progress_apply(get_more_variant_data, axis = 1)
     else:
         variants_df.progress_apply(get_more_variant_data, axis = 1)

--- a/scripts/document_types/variant.py
+++ b/scripts/document_types/variant.py
@@ -2,13 +2,20 @@
 import pandas as pd
 from tqdm import tqdm
 
-def get_variant_data(connection, limit=0):
+def get_variant_data(connection, limit=0, test = False):
     '''
     Get Variant data for Solr document.
     '''
 
+    # Special variant IDs that represent 
+    testAssociationId = [
+        42893, # Missing from solr slim
+        47195, # kgp ID
+    ]
+
     # function to retrieve further data from the database:
     def get_more_variant_data(row):
+
         # Extracting basic variant information:
         resourcename = 'variant'
         ID = row['ID']
@@ -90,7 +97,9 @@ def get_variant_data(connection, limit=0):
 
     # Step 3: Calling apply to retrieve all variant data:
     if limit != 0:
-        variants_df[1:limit].progress_apply(get_more_variant_data, axis = 1)
+        variants_df[0:limit].progress_apply(get_more_variant_data, axis = 1)
+    elif test:
+        variants_df[variants_df['ID'].isin(testAssociationId)].progress_apply(get_more_variant_data, axis = 1)
     else:
         variants_df.progress_apply(get_more_variant_data, axis = 1)
 

--- a/scripts/generate_solr_docs.py
+++ b/scripts/generate_solr_docs.py
@@ -88,7 +88,7 @@ def save_data(data, data_type=None):
         outfile.write(jsonData)
 
 def variant_data(connection, limit=0, test=False):
-    return variant.get_variant_data(connection, limit, test)
+    return variant.get_variant_data(connection, limit, testRun = test)
 
 def gene_data(connection, limit=0, test=False):
     return gene.get_gene_data(connection, RESTURL, limit)

--- a/scripts/generate_solr_docs.py
+++ b/scripts/generate_solr_docs.py
@@ -88,7 +88,7 @@ def save_data(data, data_type=None):
         outfile.write(jsonData)
 
 def variant_data(connection, limit=0, test=False):
-    return variant.get_variant_data(connection, limit)
+    return variant.get_variant_data(connection, limit, test)
 
 def gene_data(connection, limit=0, test=False):
     return gene.get_gene_data(connection, RESTURL, limit)
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--database', default='SPOTREL', choices=['DEV3', 'SPOTREL'],
                         help='Run as (default: SPOTREL).')
-    parser.add_argument('--limit', type=int, help='Limit the number of created documents to this number for testing purposes.')
+    parser.add_argument('--limit', type=int, help='Limit the number of created documents to this number for testing purposes.', default = 0)
     parser.add_argument('--document', default='publication',
                         choices=['publication', 'trait', 'variant', 'gene', 'all'],
                         help='Run as (default: publication).')

--- a/solr_config/schema.xml
+++ b/solr_config/schema.xml
@@ -113,7 +113,6 @@
   <field name="description" type="text_general" indexed="false" stored="true" multiValued="false" />
   <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
   <field name="title" type="text_general" indexed="true" stored="true" multiValued="false" />
-  <field name="link" type="text_general" indexed="false" stored="true" multiValued="false" />
 
   <!-- Commonly used, but not mandatory fields shared by many document types -->
   <field name="associationCount" type="int" indexed="false" stored="true" multiValued="false" />


### PR DESCRIPTION
One single variant was missing from the variant documents in the slim solr. Bug identified and fixed. Also a key from the slim solr schema file is removed as the links to the dedicated pages are not read from the solr document but generated on the client side.  