### PR TITLE
Update OLS API Base URL by OLS4

### DIFF
--- a/QA/solr_test.py
+++ b/QA/solr_test.py
@@ -93,10 +93,10 @@ def publication_test(fatHost, identifiers):
 
     return(failed_identifiers)
 
-# https://www.ebi.ac.uk/ols/api/ontologies/efo/terms/http%253A%252F%252Fwww.ebi.ac.uk%252Fefo%252FEFO_1000649/graph
+# https://www.ebi.ac.uk/ols4/api/ontologies/efo/terms/http%253A%252F%252Fwww.ebi.ac.uk%252Fefo%252FEFO_1000649/graph
 def get_EFO_from_OLS(EFO_URL):
     encoded_EFO_URL = quote(quote(EFO_URL, safe=''), safe='')
-    URL = 'https://www.ebi.ac.uk/ols/api/ontologies/efo/terms/%s/graph' % encoded_EFO_URL
+    URL = 'https://www.ebi.ac.uk/ols4/api/ontologies/efo/terms/%s/graph' % encoded_EFO_URL
     r = requests.get(URL)
     if not r.status_code == 200:
         print(r.text)

--- a/QA/solr_test.py
+++ b/QA/solr_test.py
@@ -4,6 +4,7 @@ from tqdm import tqdm
 from requests.utils import quote
 import re
 
+from scripts.constants import OLS4_BASE_URL, ONTOLOGY_PREFIX, TERMS_PREFIX, GRAPH_PREFIX
 
 class slimSolrWalker(object):
     '''
@@ -96,7 +97,7 @@ def publication_test(fatHost, identifiers):
 # https://www.ebi.ac.uk/ols4/api/ontologies/efo/terms/http%253A%252F%252Fwww.ebi.ac.uk%252Fefo%252FEFO_1000649/graph
 def get_EFO_from_OLS(EFO_URL):
     encoded_EFO_URL = quote(quote(EFO_URL, safe=''), safe='')
-    URL = 'https://www.ebi.ac.uk/ols4/api/ontologies/efo/terms/%s/graph' % encoded_EFO_URL
+    URL = f"{OLS4_BASE_URL}/{ONTOLOGY_PREFIX}/{TERMS_PREFIX}/{encoded_EFO_URL}/{GRAPH_PREFIX}"
     r = requests.get(URL)
     if not r.status_code == 200:
         print(r.text)

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,4 @@
+OLS4_BASE_URL = "https://www.ebi.ac.uk/ols4/api/ontologies"
+ONTOLOGY_PREFIX = "efo"
+TERMS_PREFIX = "terms"
+GRAPH_PREFIX = "graph"

--- a/scripts/ols/OLSData.py
+++ b/scripts/ols/OLSData.py
@@ -1,8 +1,8 @@
 import requests, json
 import urllib
 
+from scripts.constants import OLS4_BASE_URL, ONTOLOGY_PREFIX, TERMS_PREFIX
 from scripts.ols import DataFormatter
-
 
 class OLSData:
     def __init__(self, term_iri):
@@ -17,10 +17,8 @@ class OLSData:
         term_iri = self.term_iri
         term_iri_double_encoded = urllib.parse.quote_plus(urllib.parse.quote_plus(term_iri))
 
-
         # TODO: Make robust to the term/ontology being removed from OLS
-        OLS_URL = "http://www.ebi.ac.uk/ols4/api/ontologies/{ontology_prefix:s}/terms/"\
-            "{term_iri:s}".format(ontology_prefix='efo',term_iri=term_iri_double_encoded)
+        OLS_URL = f"{OLS4_BASE_URL}/{ONTOLOGY_PREFIX}/{TERMS_PREFIX}/{term_iri_double_encoded}"
 
         no_results = {'iri': None, 'synonyms': None, 'short_form': None, 'label': None, 'description': None}
 

--- a/scripts/ols/OLSData.py
+++ b/scripts/ols/OLSData.py
@@ -19,7 +19,7 @@ class OLSData:
 
 
         # TODO: Make robust to the term/ontology being removed from OLS
-        OLS_URL = "http://www.ebi.ac.uk/ols/api/ontologies/{ontology_prefix:s}/terms/"\
+        OLS_URL = "http://www.ebi.ac.uk/ols4/api/ontologies/{ontology_prefix:s}/terms/"\
             "{term_iri:s}".format(ontology_prefix='efo',term_iri=term_iri_double_encoded)
 
         no_results = {'iri': None, 'synonyms': None, 'short_form': None, 'label': None, 'description': None}


### PR DESCRIPTION
## What
This PR:
- updates the base URL for the OLS API from `ols` to `ols4`.
- employs constants instead of hardcoded values.

## Why
The update to `ols4` is necessary as the service has transitioned to a new version.

## How
This PR replaces the base URL with the new `ols4` endpoint. The change will be tested within the `gwas-utils-dev` conda environment on the Codon cluster after merge.

## Testing
To ensure the changes work as expected, the following steps will be performed:
1. Merge the changes to the `master` branch.
2. GitLab CI/CD will deploy the updated `gwas-slim-solr` to `gwas-utils-dev` conda environment on Codon.
3. Manual testing will be carried out by:
   - Deleting existing JSON files in the dev1 solr release directory.
   - Running the `gwas-slim-solr` start script with the specified limit option.
   - Executing the `solr-update-validate` script to validate the updates on the Solr server.
4. Post-update checks will be done on the `gwas-snoopy` Solr instance to confirm the updates are reflected correctly.

---

Closes https://github.com/EBISPOT/goci/issues/1167. 