### PR TITLE
Update OLS API Base URL by OLS4 (#47)

### DIFF
--- a/QA/solr_test.py
+++ b/QA/solr_test.py
@@ -4,6 +4,7 @@ from tqdm import tqdm
 from requests.utils import quote
 import re
 
+from scripts.constants import OLS4_BASE_URL, ONTOLOGY_PREFIX, TERMS_PREFIX, GRAPH_PREFIX
 
 class slimSolrWalker(object):
     '''
@@ -93,10 +94,10 @@ def publication_test(fatHost, identifiers):
 
     return(failed_identifiers)
 
-# https://www.ebi.ac.uk/ols/api/ontologies/efo/terms/http%253A%252F%252Fwww.ebi.ac.uk%252Fefo%252FEFO_1000649/graph
+# https://www.ebi.ac.uk/ols4/api/ontologies/efo/terms/http%253A%252F%252Fwww.ebi.ac.uk%252Fefo%252FEFO_1000649/graph
 def get_EFO_from_OLS(EFO_URL):
     encoded_EFO_URL = quote(quote(EFO_URL, safe=''), safe='')
-    URL = 'https://www.ebi.ac.uk/ols/api/ontologies/efo/terms/%s/graph' % encoded_EFO_URL
+    URL = f"{OLS4_BASE_URL}/{ONTOLOGY_PREFIX}/{TERMS_PREFIX}/{encoded_EFO_URL}/{GRAPH_PREFIX}"
     r = requests.get(URL)
     if not r.status_code == 200:
         print(r.text)

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,4 @@
+OLS4_BASE_URL = "https://www.ebi.ac.uk/ols4/api/ontologies"
+ONTOLOGY_PREFIX = "efo"
+TERMS_PREFIX = "terms"
+GRAPH_PREFIX = "graph"

--- a/scripts/ols/OLSData.py
+++ b/scripts/ols/OLSData.py
@@ -1,8 +1,8 @@
 import requests, json
 import urllib
 
+from scripts.constants import OLS4_BASE_URL, ONTOLOGY_PREFIX, TERMS_PREFIX
 from scripts.ols import DataFormatter
-
 
 class OLSData:
     def __init__(self, term_iri):
@@ -17,10 +17,8 @@ class OLSData:
         term_iri = self.term_iri
         term_iri_double_encoded = urllib.parse.quote_plus(urllib.parse.quote_plus(term_iri))
 
-
         # TODO: Make robust to the term/ontology being removed from OLS
-        OLS_URL = "http://www.ebi.ac.uk/ols/api/ontologies/{ontology_prefix:s}/terms/"\
-            "{term_iri:s}".format(ontology_prefix='efo',term_iri=term_iri_double_encoded)
+        OLS_URL = f"{OLS4_BASE_URL}/{ONTOLOGY_PREFIX}/{TERMS_PREFIX}/{term_iri_double_encoded}"
 
         no_results = {'iri': None, 'synonyms': None, 'short_form': None, 'label': None, 'description': None}
 


### PR DESCRIPTION
* refactor: Update OLS API base URL The OLS API base URL has been updated to use the latest version 'ols4'.

* refactor: use constants instead of hardcoded values